### PR TITLE
fix(utils): properly detect AsyncIterable values

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,10 @@ const kCharsetConversionTable = {
 
 export const DEFAULT_HEADER = { "user-agent": kDefaultUserAgent };
 
+export function isAsyncIterable(value: any): boolean {
+  return typeof value[Symbol.asyncIterator] === "function";
+}
+
 /**
  * @description Get a valid Node.js charset from the "content-type" http header.
  * @see https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
@@ -83,7 +87,7 @@ export function createBody(body: any, headers: IncomingHttpHeaders = {}): string
   if (typeof body === "undefined") {
     return void 0;
   }
-  if (Symbol.asyncIterator in body) {
+  if (isAsyncIterable(body)) {
     return body;
   }
 

--- a/test/__snapshots__/request.spec.ts.snap
+++ b/test/__snapshots__/request.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`http.get should throw a 404 Not Found error because the path is not kno
 <h1>Not Found</h1>
 <p>The requested URL was not found on this server.</p>
 <hr>
-<address>Apache/2.4.51 (Debian) Server at ws-dev.myunisoft.fr Port 443</address>
+<address>Apache/2.4.54 (Debian) Server at ws-dev.myunisoft.fr Port 443</address>
 </body></html>
 "
 `;

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -5,6 +5,23 @@ import stream from "stream";
 // Import Internal Dependencies
 import * as Utils from "../src/utils";
 
+describe("isAsyncIterable", () => {
+  it("should return false for synchronous iterable like an Array", () => {
+    expect(Utils.isAsyncIterable([])).toStrictEqual(false);
+  });
+
+  it("should return false for synchronous iterable like a primitive string", () => {
+    expect(Utils.isAsyncIterable("foobar")).toStrictEqual(false);
+  });
+
+  it("should return true for a Async Generator Function", () => {
+    async function* foo() {
+      yield "bar";
+    }
+    expect(Utils.isAsyncIterable(foo())).toStrictEqual(true);
+  });
+});
+
 describe("getEncodingCharset", () => {
   it("should return 'utf-8' if no value is provided", () => {
     expect(Utils.getEncodingCharset()).toStrictEqual("utf-8");


### PR DESCRIPTION
When we were providing a body string an Error was throw because `Symbol.asyncIterable in X` was not a valid statement. 