### PR TITLE
feat: add new ReqOptions querystring

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -1,5 +1,6 @@
 // Import Node.js Dependencies
 import { IncomingHttpHeaders } from "http";
+import { URLSearchParams } from "url";
 
 // Import Third-party Dependencies
 import * as undici from "undici";
@@ -17,6 +18,7 @@ export interface ReqOptions {
   maxRedirections?: number;
   /** Default: { "user-agent": "httpie" } */
   headers?: IncomingHttpHeaders;
+  querystring?: string | URLSearchParams;
   body?: any;
   authorization?: string;
   // Could be dynamically computed depending on the provided URI.
@@ -42,7 +44,14 @@ export interface RequestResponse<T> {
  */
 export async function request<T>(method: HttpMethod, uri: string | URL, options: ReqOptions = {}): Promise<RequestResponse<T>> {
   const { maxRedirections = 0 } = options;
+
   const computedURI = computeURI(uri);
+  if (typeof options.querystring !== "undefined") {
+    const qs = typeof options.querystring === "string" ? new URLSearchParams(options.querystring) : options.querystring;
+    for (const [key, value] of qs.entries()) {
+      computedURI.url.searchParams.set(key, value);
+    }
+  }
 
   const limit = options.limit ?? computedURI.limit ?? null;
   const dispatcher = options.agent ?? computedURI.agent ?? void 0;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -14,7 +14,14 @@ export type StreamOptions = Omit<ReqOptions, "limit">;
 
 export function pipeline(method: HttpMethod, uri: string | URL, options: StreamOptions = {}): Duplex {
   const { maxRedirections = 0 } = options;
+
   const computedURI = computeURI(uri);
+  if (typeof options.querystring !== "undefined") {
+    const qs = typeof options.querystring === "string" ? new URLSearchParams(options.querystring) : options.querystring;
+    for (const [key, value] of qs.entries()) {
+      computedURI.url.searchParams.set(key, value);
+    }
+  }
 
   const dispatcher = options.agent ?? computedURI.agent ?? void 0;
   const headers = Utils.createHeaders({ headers: options.headers, authorization: options.authorization });

--- a/test/request.spec.ts
+++ b/test/request.spec.ts
@@ -25,6 +25,17 @@ describe("http.get", () => {
     expect(typeof data.uptime).toStrictEqual("number");
   });
 
+  it("should GET query parameters provided to fastify", async() => {
+    const { data } = await get<{ name: string }>("/local/qs", {
+      querystring: new URLSearchParams({
+        name: "foobar"
+      })
+    });
+
+    expect("name" in data).toStrictEqual(true);
+    expect(data.name).toStrictEqual("foobar");
+  });
+
   it("should GET uptime by following an HTTP redirection from local fastify server", async() => {
     const { data } = await get<{ uptime: number }>("/local/redirect", { maxRedirections: 1 });
 

--- a/test/server/index.ts
+++ b/test/server/index.ts
@@ -47,6 +47,8 @@ export async function createServer(customPath = "local", port = 3000) {
     };
   });
 
+  server.get("/qs", async(request) => request.query);
+
   server.get("/home", (request, reply) => {
     reply.send(
       fs.createReadStream(path.join(kFixturesPath, "home.html"))


### PR DESCRIPTION
Add a new `querystring` options useful when you cannot use a WHATWG URL (happen when you use a defined agent path for example).

```ts
const { data: bearer } = await httpie.post<BearerToken>("alias/path", {
    querystring: new URLSearchParams({ name: "foobar" })
});
```

It will compute the URL for `alias/path` and add the parameters defined in querystring options.