### PR TITLE
feat: export Interceptable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ import {
   BodyMixin,
   MockAgent,
   mockErrors,
-  MockPool
+  MockPool,
+  Interceptable
 } from "undici";
 
 export * from "./request";
@@ -22,7 +23,6 @@ export * from "./retry";
 export * as policies from "./policies";
 export { agents, computeURI, CustomHttpAgent } from "./agents";
 export { DEFAULT_HEADER } from "./utils";
-
 
 export {
   Agent,
@@ -38,5 +38,6 @@ export {
   BodyMixin,
   MockAgent,
   mockErrors,
-  MockPool
+  MockPool,
+  Interceptable
 };


### PR DESCRIPTION
I'd like to use the `Interceptable` interface here (migrating from `undici` to `@myunisoft/httpie`)

https://github.com/NodeSecure/ossf-scorecard-sdk/blob/186405162c24ee65059d562606af4e582323d29f/test/result.spec.ts#L6